### PR TITLE
Change current line color to semi-transparent color

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,5 +1,5 @@
 @very-dark-gray: #282a36; // Background
-@dark-gray: #44475a; // Current Line & Selection
+@dark-gray: hsla(220, 100%, 80%, .08); // Current Line & Selection
 @gray: #666666;
 @light-gray: #999999;
 @very-light-gray: #f8f8f2; // Foreground


### PR DESCRIPTION
I changed current line color to semi-transparent color to be able to see bracket matcher results.

After:
![deepinscreenshot_select-area_20180207181907](https://user-images.githubusercontent.com/11137231/35927537-aaef2f4e-0c33-11e8-9aa3-8fb1b4dd31c0.png)

Before:
![deepinscreenshot_select-area_20180207182007](https://user-images.githubusercontent.com/11137231/35927546-b04b25a6-0c33-11e8-9269-7cb09a703915.png)

