### PR TITLE
Add missing language entity colors

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -30,3 +30,17 @@
 @syntax-color-added: @green;
 @syntax-color-modified: @orange;
 @syntax-color-removed: @red;
+
+// For language entity colors
+@syntax-color-variable: @red;
+@syntax-color-constant: @yellow;
+@syntax-color-property: @very-light-gray;
+@syntax-color-value: @very-light-gray;
+@syntax-color-function: @blue;
+@syntax-color-method: @blue;
+@syntax-color-class: @dark-yellow;
+@syntax-color-keyword: @purple;
+@syntax-color-tag: @red;
+@syntax-color-attribute: @yellow;
+@syntax-color-import: @purple;
+@syntax-color-snippet: @green;


### PR DESCRIPTION
Fix #15.

Before:
![image](https://user-images.githubusercontent.com/1268518/39837764-c7177a8e-53ad-11e8-9b0d-38591b7b1b85.png)

After:
![image](https://user-images.githubusercontent.com/1268518/39839013-42869d14-53b1-11e8-8f6f-863cd93ce94d.png)
