### PR TITLE
Update installation instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@
 
 Alternatively, if you are a git user, you can install the theme and keep up to date by cloning the repo directly into your `~/.atom/packages` directory.
 
-    $ git clone https://github.com/dracula/atom.git ~/.atom/packages/dracula-theme
+    git clone https://github.com/dracula/atom.git ~/.atom/packages/dracula-theme
 
 #### Install manually
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,10 +2,10 @@
 
 #### Install using Atom
 
-1.  Go to `Atom -> Preferences...`
-2.  Then select the `Install` tab
-3.  Click the `Themes` button to the right of the search box
-4.  Enter `dracula-theme` in the search box
+1. Go to `Atom -> Preferences...`
+2. Then select the `Install` tab
+3. Click the `Themes` button to the right of the search box
+4. Enter `dracula-theme` in the search box
 
 #### Install using Git
 
@@ -15,8 +15,8 @@ Alternatively, if you are a git user, you can install the theme and keep up to d
 
 #### Install manually
 
-1.  Download using the [GitHub .zip download](https://github.com/dracula/atom/archive/master.zip) option and unzip them
-2.  Move the `dracula-theme` folder to `~/.atom/packages`
+1. Download using the [GitHub .zip download](https://github.com/dracula/atom/archive/master.zip) option and unzip them
+2. Move the `dracula-theme` folder to `~/.atom/packages`
 
 #### Activating theme
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,12 +15,12 @@
 
 Alternatively, if you are a git user, you can install the theme and keep up to date by cloning the repo directly into your `~/.atom/packages` directory.
 
-    git clone https://github.com/dracula/atom.git ~/.atom/packages/dracula-theme
+    git clone https://github.com/dracula/atom.git ~/.atom/packages/dracula-syntax
 
 #### Install manually
 
 1. Download using the [GitHub .zip download](https://github.com/dracula/atom/archive/master.zip) option and unzip them
-2. Move the `dracula-theme` folder to `~/.atom/packages`
+2. Move the `dracula-syntax` folder to `~/.atom/packages`
 
 #### Activating theme
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,10 @@
 3. Click the `Themes` button to the right of the search box
 4. Enter `dracula-syntax` in the search box
 
+#### Install using Atom Package Manager
+
+    apm install dracula-syntax
+
 #### Install using Git
 
 Alternatively, if you are a git user, you can install the theme and keep up to date by cloning the repo directly into your `~/.atom/packages` directory.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 1. Go to `Atom -> Preferences...`
 2. Then select the `Install` tab
 3. Click the `Themes` button to the right of the search box
-4. Enter `dracula-theme` in the search box
+4. Enter `dracula-syntax` in the search box
 
 #### Install using Git
 


### PR DESCRIPTION
I opened a pull request to fix these installation instructions when they lived in the following repository: dracula/dracula.github.io#87.

This pull request addresses the same issue (also described in dracula/dracula.github.io#95) and adds instructions for installing with Atom Package Manager.